### PR TITLE
rename gd2md to normalization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,12 +28,12 @@ upload-templates:
 	@export AWS_REGION=$(AWS_REGION)
 	aws s3 sync cloudformation/ $(S3_BUCKET_TEMPLATE_URI) --exclude="*" --include="*.yml"
 
-.PHONY: upload-gd2md-lambda
-upload-gd2md-lambda:
+.PHONY: upload-normalization-lambda
+upload-normalization-lambda:
 	@export AWS_REGION=$(AWS_REGION)
-	zip lambda_functions/gd2md.zip lambda_functions/normalization.py
-	aws s3 cp lambda_functions/gd2md.zip $(S3_BUCKET_LAMBDA_URI)/gd2md.zip
-	rm lambda_functions/gd2md.zip
+	zip lambda_functions/normalization.zip lambda_functions/normalization.py
+	aws s3 cp lambda_functions/normalization.zip $(S3_BUCKET_LAMBDA_URI)/normalization.zip
+	rm lambda_functions/normalization.zip
 
 .PHONY: upload-plumbing-lambda
 upload-plumbing-lambda:

--- a/cloudformation/guardduty-event-normalization.yml
+++ b/cloudformation/guardduty-event-normalization.yml
@@ -8,7 +8,7 @@ Parameters:
     Default: public.
     Description: >
       A prefix string describing the S3 bucket name in each region containing
-      the gd2md.zip and plumbing.zip Lambda code. This parameter is appended with
+      the normalization.zip and plumbing.zip Lambda code. This parameter is appended with
       the region name. For example my-bucket- would be turned into
       my-bucket-us-west-2 for us-west-2. Set this to blank if your bucket name
       has no prefix.
@@ -17,7 +17,7 @@ Parameters:
     Default: .infosec.mozilla.org
     Description: >
       A suffix string describing the S3 bucket name in each region containing
-      the gd2md.zip and plumbing.zip Lambda code. This parameter is prepended with
+      the normalization.zip and plumbing.zip Lambda code. This parameter is prepended with
       the region name. For example -my-bucket would be turned into
       us-west-2-my-bucket for us-west-2. Set this to blank if your bucket name
       has no suffix
@@ -125,7 +125,7 @@ Resources:
       Role: !GetAtt 'GuardDutyToMozDefRole.Arn'
       Code:
         S3Bucket: !Join [ '', [ !Ref LambdaCodeS3BucketNamePrefix, !Ref 'AWS::Region', !Ref LambdaCodeS3BucketNameSuffix ] ]
-        S3Key: !Join [ '', [ !Ref LambdaCodeS3Path, "gd2md.zip" ] ]
+        S3Key: !Join [ '', [ !Ref LambdaCodeS3Path, "normalization.zip" ] ]
       Environment:
         Variables:
           minSeverityLevel: 'LOW'

--- a/cloudformation/guardduty-invitation-manager.yml
+++ b/cloudformation/guardduty-invitation-manager.yml
@@ -21,7 +21,7 @@ Parameters:
     Default: public.
     Description: >
       A prefix string describing the S3 bucket name in each region containing
-      the gd2md.zip and plumbing.zip Lambda code. This parameter is appended with
+      the normalization.zip and plumbing.zip Lambda code. This parameter is appended with
       the region name. For example my-bucket- would be turned into
       my-bucket-us-west-2 for us-west-2. Set this to blank if your bucket name
       has no prefix.
@@ -30,7 +30,7 @@ Parameters:
     Default: .infosec.mozilla.org
     Description: >
       A suffix string describing the S3 bucket name in each region containing
-      the gd2md.zip and plumbing.zip Lambda code. This parameter is prepended with
+      the normalization.zip and plumbing.zip Lambda code. This parameter is prepended with
       the region name. For example -my-bucket would be turned into
       us-west-2-my-bucket for us-west-2. Set this to blank if your bucket name
       has no suffix

--- a/lambda_functions/plumbing.py
+++ b/lambda_functions/plumbing.py
@@ -33,7 +33,7 @@ EVENT_PATTERN = {
 
 NORMALIZER_LAMBDA_FUNCTION = os.getenv(
     'NORMALIZER_LAMBDA_FUNCTION',
-    'arn:aws:lambda:us-east-1:371522382791:function:gd2md-findingsToMozDef-1O04GFRLK0EJQ'
+    'arn:aws:lambda:us-east-1:371522382791:function:findingsToMozDef-1O04GFRLK0EJQ'
 )
 
 
@@ -146,7 +146,7 @@ def setup_sns_publishing(boto_session):
         Targets=[
             {
                 'Arn': find_or_create_sns_topic(boto_session),
-                'Id': 'gd2MdSNS',
+                'Id': 'normalizationSNS',
             }
         ]
     )


### PR DESCRIPTION
Fixes #23 
It renames gd2md terms to normalization ... or simply withdraws it when not relevant anymore.