### PR TITLE
Support multiple orgs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,8 @@ S3_BUCKET_LAMBDA_PATH	:= guardduty-multi-account-manager/lambda
 S3_BUCKET_TEMPLATE_URI	:= s3://$(S3_BUCKET_NAME)/$(S3_BUCKET_TEMPLATE_PATH)
 S3_BUCKET_LAMBDA_URI	:= s3://$(S3_BUCKET_NAME)/$(S3_BUCKET_LAMBDA_PATH)
 PARENT_TEMPLATE_URI	:= https://s3.amazonaws.com/$(S3_BUCKET_NAME)/$(S3_BUCKET_TEMPLATE_PATH)/guardduty-multi-account-manager-parent.yml
+LAMBDA_BUCKET_PREFIX	:= $(shell v='$(S3_BUCKET_NAME)'; echo "$${v%%us-west-2*}")
+LAMBDA_BUCKET_SUFFIX	:= $(shell v='$(S3_BUCKET_NAME)'; echo "$${v\#\#*us-west-2}")
 
 all:
 	@echo 'Available make targets:'
@@ -44,14 +46,54 @@ upload-plumbing-lambda:
 
 .PHONY: upload-invitation_manager-lambda
 upload-invitation_manager-lambda:
-	@export AWS_REGION=$(AWS_REGION)
 	zip lambda_functions/invitation_manager.zip lambda_functions/invitation_manager.py
-	aws s3 cp lambda_functions/invitation_manager.zip $(S3_BUCKET_LAMBDA_URI)/invitation_manager.zip
+	AWS_REGION=$(AWS_REGION) aws s3 cp lambda_functions/invitation_manager.zip $(S3_BUCKET_LAMBDA_URI)/invitation_manager.zip
 	rm lambda_functions/invitation_manager.zip
 
 .PHONY: upload-templates create-stack
 create-stack:
 	@export AWS_REGION=$(AWS_REGION)
+
+	# $${$(S3_BUCKET_NAME)##us-west-2*}
+	# https://github.com/aws/aws-cli/issues/870#issuecomment-51629161
 	aws cloudformation create-stack --stack-name guardduty-multi-account-manager \
 	  --capabilities CAPABILITY_IAM \
+	  --parameters \
+	    ParameterKey=CloudFormationTemplatePrefix,ParameterValue=https://s3.amazonaws.com/$(S3_BUCKET_NAME)/$(S3_BUCKET_TEMPLATE_PATH)/ \
+	    ParameterKey=LambdaCodeS3BucketNamePrefix,ParameterValue=$(LAMBDA_BUCKET_PREFIX) \
+	    ParameterKey=LambdaCodeS3BucketNameSuffix,ParameterValue=$(LAMBDA_BUCKET_SUFFIX) \
+	    ParameterKey=LambdaCodeS3Path,ParameterValue=$(S3_BUCKET_LAMBDA_PATH)/ \
+	    ParameterKey=OrganizationAccountArns,ParameterValue=\'$(ORGANIZAION_ACCOUNT_ARNS)\' \
+	    ParameterKey=AccountFilterList,ParameterValue=$(ACCOUNT_FILTER_LIST) \
 	  --template-url $(PARENT_TEMPLATE_URI)
+
+.PHONY: create-invitation-manager-stack
+create-invitation-manager-stack:
+	AWS_REGION=$(AWS_REGION) aws cloudformation create-stack --stack-name guardduty-invitation-manager \
+	  --capabilities CAPABILITY_IAM \
+	  --parameters \
+	    ParameterKey=LambdaCodeS3BucketNamePrefix,ParameterValue=$(LAMBDA_BUCKET_PREFIX) \
+	    ParameterKey=LambdaCodeS3BucketNameSuffix,ParameterValue=$(LAMBDA_BUCKET_SUFFIX) \
+	    ParameterKey=LambdaCodeS3Path,ParameterValue=$(S3_BUCKET_LAMBDA_PATH)/ \
+	    ParameterKey=OrganizationAccountArns,ParameterValue=\'$(ORGANIZAION_ACCOUNT_ARNS)\' \
+	    ParameterKey=AccountFilterList,ParameterValue=$(ACCOUNT_FILTER_LIST) \
+	  --template-url https://s3.amazonaws.com/$(S3_BUCKET_NAME)/$(S3_BUCKET_TEMPLATE_PATH)/guardduty-invitation-manager.yml
+
+.PHONY: upload-templates update-stack
+update-stack:
+	@export AWS_REGION=$(AWS_REGION)
+	aws cloudformation update-stack --stack-name guardduty-multi-account-manager \
+	  --capabilities CAPABILITY_IAM \
+	  --template-url $(PARENT_TEMPLATE_URI)
+
+
+# To upload to staging and test
+# logged into infosec-dev AWS account
+#  make upload-templates S3_BUCKET_NAME=public.us-west-2.security.allizom.org
+#  make upload-invitation_manager-lambda S3_BUCKET_NAME=public.us-west-2.security.allizom.org
+# logged into infosec-prod (because this is the account that's trusted)
+#  make create-stack S3_BUCKET_NAME=public.us-west-2.security.allizom.org
+# or
+#  make create-invitation-manager-stack S3_BUCKET_NAME=public.us-west-2.security.allizom.org ORGANIZAION_ACCOUNT_ARNS=arn:aws:iam::329567179436:role/Infosec-Organization-Reader,arn:aws:iam::943761894018:role/Infosec-Organization-Reader
+
+

--- a/cloudformation/guardduty-invitation-manager.yml
+++ b/cloudformation/guardduty-invitation-manager.yml
@@ -6,16 +6,14 @@ Parameters:
   AccountFilterList:
     Type: String
     Default: ''
-    # Default: 656532927350
     Description: Space delimited list of account IDs to filter on. Leave this empty to process all accounts
-  OrganizationAccountArn:
+  OrganizationAccountArns:
     Type: String
     Default: ''
-    # Default: arn:aws:iam::329567179436:role/Infosec-Organization-Reader
     Description: >
-      ARN of an IAM Role to assume in order to query the AWS Organization parent
-      if the Org parent is a different AWS account. Leave this empty if you are
-      deploying within the AWS Organization parent account
+      ARNs of IAM Roles to assume in order to query the AWS Organization parents
+      if the Org parents are different AWS accounts. Leave this empty if you are
+      deploying within a single AWS Organization parent account
   LambdaCodeS3BucketNamePrefix:
     Type: String
     Default: public.
@@ -61,7 +59,7 @@ Resources:
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
       Policies:
-        - PolicyName: "AllowRoleAssumption"
+        - PolicyName: "AllowRoleAssumptionOfMembers"
           PolicyDocument:
             Version: "2012-10-17"
             Statement:
@@ -70,7 +68,14 @@ Resources:
                 Resource:
                   - arn:aws:iam::*:role/multi-account-guard-duty/*
                   - arn:aws:iam::*:role/mutli-account-guard-duty/*
-                  - !Ref OrganizationAccountArn
+                  - !Ref OrganizationAccountArns
+        - PolicyName: "AllowRoleAssumptionOfOrgReaders"
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: "Allow"
+                Action: sts:AssumeRole
+                Resource: !Split [ ",", !Ref OrganizationAccountArns ]
         - PolicyName: "AllowSTSGetCallerIdentity"
           PolicyDocument:
             Version: "2012-10-17"
@@ -126,7 +131,7 @@ Resources:
           ACCOUNT_FILTER_LIST: !Ref AccountFilterList
           DYNAMODB_TABLE_NAME: !FindInMap [ Variables, DynamoDBTable, Name ]
           DB_CATEGORY: !FindInMap [ Variables, DynamoDBTable, Category ]
-          ORGANIZATION_IAM_ROLE_ARN: !Ref OrganizationAccountArn
+          ORGANIZATION_IAM_ROLE_ARNS: !Ref OrganizationAccountArns
   InvitationManagerScheduledRule:
     Type: AWS::Events::Rule
     Properties:

--- a/cloudformation/guardduty-invitation-manager.yml
+++ b/cloudformation/guardduty-invitation-manager.yml
@@ -115,7 +115,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Runtime: python3.6
-      Timeout: 60
+      Timeout: 600
       Handler: lambda_functions/invitation_manager.handle
       Role: !GetAtt InvitationManagerIAMRole.Arn
       Code:
@@ -131,7 +131,7 @@ Resources:
     Type: AWS::Events::Rule
     Properties:
       Description: "Trigger GuardDuty Invitation Manager run thrice daily"
-      ScheduleExpression: "cron(14,19,24 11 * * ? *)"
+      ScheduleExpression: "cron(14,29,44 11 * * ? *)"
       State: "ENABLED"
       Targets:
         - Arn: !GetAtt InvitationManagerFunction.Arn

--- a/cloudformation/guardduty-multi-account-manager-parent.yml
+++ b/cloudformation/guardduty-multi-account-manager-parent.yml
@@ -8,14 +8,13 @@ Parameters:
     Default: ''
     # Default: 656532927350
     Description: Space delimited list of account IDs to filter on. Leave this empty to process all accounts
-  OrganizationAccountArn:
+  OrganizationAccountArns:
     Type: String
     Default: ''
-    # Default: arn:aws:iam::329567179436:role/Infosec-Organization-Reader
     Description: >
-      ARN of an IAM Role to assume in order to query the AWS Organization parent
-      if the Org parent is a different AWS account. Leave this empty if you are
-      deploying within the AWS Organization parent account
+      ARNs of IAM Roles to assume in order to query the AWS Organization parents
+      if the Org parents are different AWS accounts. Leave this empty if you are
+      deploying within a single AWS Organization parent account
 Mappings:
   Variables:
     CloudFormationTemplate:
@@ -37,7 +36,7 @@ Resources:
         LambdaCodeS3BucketNameSuffix: !FindInMap [ Variables, LambdaCode, BucketNameSuffix ]
         LambdaCodeS3Path: !FindInMap [ Variables, LambdaCode, DirectoryPath ]
         AccountFilterList: !Ref AccountFilterList
-        OrganizationAccountArn: !Ref OrganizationAccountArn
+        OrganizationAccountArns: !Ref OrganizationAccountArns
   GuardDutyEventNormalization:
     Type: AWS::CloudFormation::Stack
     Properties:

--- a/cloudformation/guardduty-multi-account-manager-parent.yml
+++ b/cloudformation/guardduty-multi-account-manager-parent.yml
@@ -2,12 +2,14 @@ AWSTemplateFormatVersion: 2010-09-09
 Description: Mozilla Multi Account Manager for AWS GuardDuty
 Metadata:
   Source: https://github.com/mozilla/guardduty-multi-account-manager/tree/master/cloudformation
+  TemplateVersion: 1.0.1
 Parameters:
   AccountFilterList:
     Type: String
     Default: ''
-    # Default: 656532927350
-    Description: Space delimited list of account IDs to filter on. Leave this empty to process all accounts
+    Description: >
+      Space delimited list of account IDs to filter on. Leave this empty to
+      process all accounts
   OrganizationAccountArns:
     Type: String
     Default: ''
@@ -15,14 +17,30 @@ Parameters:
       ARNs of IAM Roles to assume in order to query the AWS Organization parents
       if the Org parents are different AWS accounts. Leave this empty if you are
       deploying within a single AWS Organization parent account
-Mappings:
-  Variables:
-    CloudFormationTemplate:
-      Prefix: https://s3-us-west-2.amazonaws.com/public.us-west-2.infosec.mozilla.org/guardduty-multi-account-manager/cf/
-    LambdaCode:
-      BucketNamePrefix: public.
-      BucketNameSuffix: .infosec.mozilla.org
-      DirectoryPath: guardduty-multi-account-manager/lambda/
+  CloudFormationTemplatePrefix:
+    Type: String
+    Default: https://s3-us-west-2.amazonaws.com/public.us-west-2.infosec.mozilla.org/guardduty-multi-account-manager/cf/
+    Description: >
+      The S3 bucket and path containing the child CloudFormation templates
+  LambdaCodeS3BucketNamePrefix:
+    Type: String
+    Default: public.
+    Description: >
+      The section of the S3 bucket name preceding the region. For example the
+      bucket "public.us-west-2.infosec.mozilla.org" would have a prefix of
+      "public."
+  LambdaCodeS3BucketNameSuffix:
+    Type: String
+    Default: .infosec.mozilla.org
+    Description: >
+      The section of the S3 bucket name succeeds the region. For example the
+      bucket "public.us-west-2.infosec.mozilla.org" would have a suffix of
+      ".infosec.mozilla.org"
+  LambdaCodeS3Path:
+    Type: String
+    Default: guardduty-multi-account-manager/lambda/
+    Description: >
+      The directory path in the Lambda code bucket containing the Lambda code
 Resources:
   GuardDutyInvitationManager:
     Type: AWS::CloudFormation::Stack
@@ -30,11 +48,11 @@ Resources:
       Tags:
         - Key: application
           Value: guardduty-multi-account-manager
-      TemplateURL: !Join [ '', [ !FindInMap [ Variables, CloudFormationTemplate, Prefix ], guardduty-invitation-manager.yml ] ]
+      TemplateURL: !Join [ '', [ !Ref 'CloudFormationTemplatePrefix', guardduty-invitation-manager.yml ] ]
       Parameters:
-        LambdaCodeS3BucketNamePrefix: !FindInMap [ Variables, LambdaCode, BucketNamePrefix ]
-        LambdaCodeS3BucketNameSuffix: !FindInMap [ Variables, LambdaCode, BucketNameSuffix ]
-        LambdaCodeS3Path: !FindInMap [ Variables, LambdaCode, DirectoryPath ]
+        LambdaCodeS3BucketNamePrefix: !Ref LambdaCodeS3BucketNamePrefix
+        LambdaCodeS3BucketNameSuffix: !Ref LambdaCodeS3BucketNameSuffix
+        LambdaCodeS3Path: !Ref LambdaCodeS3Path
         AccountFilterList: !Ref AccountFilterList
         OrganizationAccountArns: !Ref OrganizationAccountArns
   GuardDutyEventNormalization:
@@ -43,8 +61,8 @@ Resources:
       Tags:
         - Key: application
           Value: guardduty-multi-account-manager
-      TemplateURL: !Join [ '', [ !FindInMap [ Variables, CloudFormationTemplate, Prefix ], guardduty-event-normalization.yml ] ]
+      TemplateURL: !Join [ '', [ !Ref 'CloudFormationTemplatePrefix', guardduty-event-normalization.yml ] ]
       Parameters:
-        LambdaCodeS3BucketNamePrefix: !FindInMap [ Variables, LambdaCode, BucketNamePrefix ]
-        LambdaCodeS3BucketNameSuffix: !FindInMap [ Variables, LambdaCode, BucketNameSuffix ]
-        LambdaCodeS3Path: !FindInMap [ Variables, LambdaCode, DirectoryPath ]
+        LambdaCodeS3BucketNamePrefix: !Ref LambdaCodeS3BucketNamePrefix
+        LambdaCodeS3BucketNameSuffix: !Ref LambdaCodeS3BucketNameSuffix
+        LambdaCodeS3Path: !Ref LambdaCodeS3Path

--- a/lambda_functions/invitation_manager.py
+++ b/lambda_functions/invitation_manager.py
@@ -9,7 +9,6 @@ if root.handlers:
     for handler in root.handlers:
         root.removeHandler(handler)
 
-
 logging.basicConfig(
     level=logging.INFO,
     handlers=[logging.StreamHandler()]
@@ -17,7 +16,6 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 logging.getLogger('botocore').setLevel(logging.CRITICAL)
 logging.getLogger('urllib3').setLevel(logging.CRITICAL)
-
 
 DYNAMODB_TABLE_NAME = os.environ.get(
     'DYNAMODB_TABLE_NAME', 'cloudformation-stack-emissions')
@@ -93,7 +91,8 @@ def create_detector(boto_session, region_name, account_id=''):
     gd = boto_session.client('guardduty', region_name=region_name)
     response = gd.create_detector(
         Enable=True,
-        # FindingPublishingFrequency='FIFTEEN_MINUTES'  # We need a newer version of boto3 to support this argument
+        # FindingPublishingFrequency='FIFTEEN_MINUTES'
+        # We need a newer version of boto3 to support this argument
         # https://github.com/boto/botocore/commit/31f3dfd37a89b018f818807d9977d6d4e5090467
     )
     logger.info(
@@ -155,7 +154,7 @@ def get_account_role_map(boto_session, region_name):
             for x in items
             if x.get('category') == DB_CATEGORY
             and {'aws-account-id',
-                  'GuardDutyMemberAccountIAMRoleArn'} <= set(x)}
+                 'GuardDutyMemberAccountIAMRoleArn'} <= set(x)}
 
 
 def tear_down_members(account_ids):
@@ -165,45 +164,45 @@ def tear_down_members(account_ids):
     account_id_role_arn_map = get_account_role_map(
         local_boto_session, 'us-west-2')
     for region_name in guardduty_regions:
-        detector_id = get_all_detectors(local_boto_session, region_name)['DetectorIds'][0]
+        detector_id = get_all_detectors(
+            local_boto_session, region_name)['DetectorIds'][0]
         client = local_boto_session.client(
             'guardduty', region_name=region_name)
-        response = client.delete_members(
+        client.delete_members(
             AccountIds=account_ids,
             DetectorId=detector_id
         )
         logger.info('{}: Deleted member {} from master detector {}'.format(
-                region_name, account_ids, detector_id))
+            region_name, account_ids, detector_id))
 
         for account_id in account_ids:
-            member_boto_session = get_session(account_id_role_arn_map[account_id])
+            member_boto_session = get_session(
+                account_id_role_arn_map[account_id])
             member_client = member_boto_session.client(
                 'guardduty', region_name=region_name)
             for member_detector_id in get_all_detectors(
                     member_boto_session, region_name)['DetectorIds']:
                 try:
-                    response = member_client.disassociate_from_master_account(
-                        DetectorId=member_detector_id
-                    )
-                    logger.info('{}: {} : Dissasociated member dector id {} from master'.format(
-                        region_name, account_id, member_detector_id))
-                except:
-                    pass
-                try:
-                    response = member_client.delete_detector(
-                        DetectorId=member_detector_id
-                    )
+                    member_client.disassociate_from_master_account(
+                        DetectorId=member_detector_id)
                     logger.info(
-                        '{}: {} : Deleted member dector id {}'.format(
+                        '{}: {} : Dissasociated member dector id {} from '
+                        'master'.format(
                             region_name, account_id, member_detector_id))
                 except:
                     pass
-            response = member_client.delete_invitations(
-                AccountIds=[local_account_id])
+                try:
+                    member_client.delete_detector(
+                        DetectorId=member_detector_id)
+                    logger.info(
+                        '{}: {} : Deleted member detector id {}'.format(
+                            region_name, account_id, member_detector_id))
+                except:
+                    pass
+            member_client.delete_invitations(AccountIds=[local_account_id])
             logger.info(
-                '{}: {} : Inivitation from {} deleted'.format(
+                '{}: {} : Invitation from {} deleted'.format(
                     region_name, account_id, local_account_id))
-
 
 
 def handle(event, context):
@@ -221,7 +220,7 @@ def handle(event, context):
       * For each account
         * Update member account detector to enabled if DISABLED
         * Get or create a detector in the member account
-        * For members with a pending invitationaAccept the invitation in the
+        * For members with a pending invitation, accept the invitation in the
           member account
 
     Set environment variables
@@ -289,14 +288,14 @@ def handle(event, context):
             {'AccountId': account_id, 'Email': email}
             for account_id, email in organizations_account_id_map.items()
             if account_id in account_id_role_arn_map.keys() and
-               (account_id not in members
-                or account_id in get_members('REMOVED'))]
+            (account_id not in members
+             or account_id in get_members('REMOVED'))]
         if account_details:
             client.create_members(
                 AccountDetails=account_details,
                 DetectorId=local_detector_id)
             logger.info(
-                '{} : Member created : {}'.format(
+                '{} : Members created : {}'.format(
                     region_name, account_details))
         # Invite members that have been created
         account_ids_to_invite = get_members('CREATED', 'RESIGNED')
@@ -348,6 +347,5 @@ def handle(event, context):
                         DetectorId=detector_id,
                         InvitationId=invitation_id,
                         MasterId=local_account_id)
-                    logger.info(
-                        '{} : {} : Accepted member invite on their behalf'.format(
-                            region_name, account_id))
+                    logger.info('{} : {} : Accepted member invite on their '
+                                'behalf'.format(region_name, account_id))


### PR DESCRIPTION
* Fix bug of function running out of execution time 
* Add support for multiple AWS Organizations
  * This allows passing a comma delimited list of AWS Organization ARNs instead of a single ARN
* Code cleanup
  * PEP008ing lines
  * Fixing typos
* Allow passing variables in as Parameters
  * This changes the Mappings to Parameters with defaults
so that different values can be passed in.
  * The Makefile is updated to pass these variables in so that staging deployments can be done