### PR TITLE
Add case for EMAILVERIFICATIONFAILED where we delete the member

### DIFF
--- a/cloudformation/guardduty-invitation-manager.yml
+++ b/cloudformation/guardduty-invitation-manager.yml
@@ -99,6 +99,7 @@ Resources:
               - Effect: "Allow"
                 Action:
                 - guardduty:GetMembers
+                - guardduty:ListMembers
                 - guardduty:CreateMembers
                 - guardduty:InviteMembers
                 Resource: '*'

--- a/cloudformation/guardduty-invitation-manager.yml
+++ b/cloudformation/guardduty-invitation-manager.yml
@@ -120,7 +120,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Runtime: python3.6
-      Timeout: 600
+      Timeout: 900
       Handler: lambda_functions/invitation_manager.handle
       Role: !GetAtt InvitationManagerIAMRole.Arn
       Code:

--- a/lambda_functions/invitation_manager.py
+++ b/lambda_functions/invitation_manager.py
@@ -273,11 +273,14 @@ def handle(event, context):
         # Fetch the GuardDuty members list
         client = local_boto_session.client(
             'guardduty', region_name=region_name)
-        response = client.get_members(
-            AccountIds=list(account_id_role_arn_map),
-            DetectorId=local_detector_id)
+        list_of_members = [
+            y for sublist in [
+                x['Members'] for x in client.get_paginator(
+                    'list_members').paginate(
+                    DetectorId=local_detector_id, OnlyAssociated="FALSE")]
+            for y in sublist]
         members = {x['AccountId']: x['RelationshipStatus']
-                   for x in response['Members']}
+                   for x in list_of_members}
         logger.debug('{} : Member dict : {}'.format(region_name, members))
 
         # Create a get_members function to work with the members list

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ cfnlint
 pytest
 pytest-watch
 pytest-cov
+boto3


### PR DESCRIPTION
This will start the process over from the beginning
Also, handle the case where the GuardDuty parent list doesn't match
the child state. We only encountered this becasuse of the bug
regarding EMAILVERIFICATIONFAILED but couldn't hurt to handle this case
gracefully even if it won't come up


Switch from using GetMembers to ListMembers to workaround limit of 50 accounts
There's an undocumented limit either on the account ids submitted
for a guardduty:GetMembers request or on the responses. Switching
to ListMembers to work around this