### PR TITLE
Allow to use a different region than us-west-2

### DIFF
--- a/cloudformation/guardduty-invitation-manager.yml
+++ b/cloudformation/guardduty-invitation-manager.yml
@@ -43,6 +43,7 @@ Mappings:
   Variables:
     DynamoDBTable:
       Name: cloudformation-stack-emissions
+      Region: us-west-2
       Category: GuardDuty Multi Account Member Role
 Resources:
   InvitationManagerIAMRole:
@@ -131,6 +132,7 @@ Resources:
         Variables:
           ACCOUNT_FILTER_LIST: !Ref AccountFilterList
           DYNAMODB_TABLE_NAME: !FindInMap [ Variables, DynamoDBTable, Name ]
+          DYNAMODB_TABLE_REGION: !FindInMap [ Variables, DynamoDBTable, Region ]
           DB_CATEGORY: !FindInMap [ Variables, DynamoDBTable, Category ]
           ORGANIZATION_IAM_ROLE_ARNS: !Ref OrganizationAccountArns
   InvitationManagerScheduledRule:


### PR DESCRIPTION
As mentioned in the issue #36, we can not use the tool if our DynamoDB table is not deployed in us-west-2. This PR allows to easily change the dynamodb region within the CloudFormation mappings.