### PR TITLE
Improve cfn-lint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cfnlint
+cfn-lint
 pytest
 pytest-watch
 pytest-cov


### PR DESCRIPTION
Because the package "cfnlint" is quite old and unmaintained (command remains nammed "cfn-lint") 