### PR TITLE
Update Python runtime to 3.9

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,16 @@
+name: run-tests
+on:
+  pull_request:
+    branches:
+      - master
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    name: Check CloudFormation syntax with cfn-lint
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2.2.2
+        with:
+          python-version: 3.9
+      - run: pip install --requirement $GITHUB_WORKSPACE/requirements.txt
+      - run: make cfn-lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: python
-python:
-  - "3.6"
-# command to install dependencies
-install:
-  - pip install -r requirements.txt
-# command to run tests
-script:
-  - make cfn-lint

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ This is why we elected to create GuardDuty Multi-Account Manager
 
 ## What is it?
 
-GuardDuty Multi-Account Manager is a series of lambda functions designed to do
-the following:
+GuardDuty Multi-Account Manager is a series of AWS Lambda functions designed to
+do the following:
 
 * Enable GuardDuty Masters in all AWS Regions present and future.
 * Empower account owners to decide to enable GuardDuty
@@ -85,16 +85,22 @@ the following:
   
 ### Getting Started
 
+If you want just the account management functionality :
+
+* Deploy the Cloudformation Stack from
+  [`cloudformation/guardduty-invitation-manager.yml`](https://s3-us-west-2.amazonaws.com/public.us-west-2.infosec.mozilla.org/guardduty-multi-account-manager/cf/guardduty-invitation-manager.yml) in the master
+  account. [![Launch GuardDuty Multi Account Manager](https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png)](https://console.aws.amazon.com/cloudformation/home?region=us-west-2#/stacks/new?stackName=guardduty-invitation-manager&templateURL=https://s3-us-west-2.amazonaws.com/public.us-west-2.infosec.mozilla.org/guardduty-multi-account-manager/cf/guardduty-invitation-manager.yml)
+
+If you want the account management and centralized, normalized GuardDuty data in
+an SQS queue
+
 * Deploy the Cloudformation Stack from
   [`cloudformation/guardduty-multi-account-manager-parent.yml`](https://s3-us-west-2.amazonaws.com/public.us-west-2.infosec.mozilla.org/guardduty-multi-account-manager/cf/guardduty-multi-account-manager-parent.yml) in the master
   account. [![Launch GuardDuty Multi Account Manager](https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png)](https://console.aws.amazon.com/cloudformation/home?region=us-west-2#/stacks/new?stackName=guardduty-multi-account-manager&templateURL=https://s3-us-west-2.amazonaws.com/public.us-west-2.infosec.mozilla.org/guardduty-multi-account-manager/cf/guardduty-multi-account-manager-parent.yml)
 
-* The stack will spin up and create all Master Detectors in all regions, a
-  normalization functions, and all SNS Topics with CloudWatch events.
-
 ### Onboarding Accounts
 
-1. Ensure that the the mappings are configured in the
+1. Ensure that the mappings are configured in the
    [`cloudformation/guardduty-member-account-role.yml`](cloudformation/guardduty-member-account-role.yml)
    template as described above
 2. Deploy the customized [`cloudformation/guardduty-member-account-role.yml`](cloudformation/guardduty-member-account-role.yml)

--- a/cloudformation/guardduty-event-normalization.yml
+++ b/cloudformation/guardduty-event-normalization.yml
@@ -119,7 +119,7 @@ Resources:
   findingsToMozDef:
     Type: AWS::Lambda::Function
     Properties:
-      Runtime: 'python3.6'
+      Runtime: 'python3.9'
       Timeout: 300
       Handler: lambda_functions/normalization.handle
       Role: !GetAtt 'GuardDutyToMozDefRole.Arn'
@@ -133,7 +133,7 @@ Resources:
   gdPlumbing:
     Type: AWS::Lambda::Function
     Properties:
-      Runtime: 'python3.6'
+      Runtime: 'python3.9'
       Timeout: 300
       Handler: lambda_functions/plumbing.handle
       Role: !GetAtt 'GuardDutyPlumbingRole.Arn'

--- a/cloudformation/guardduty-invitation-manager.yml
+++ b/cloudformation/guardduty-invitation-manager.yml
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: 2010-09-09
-Description: Mozilla Multi Account Manager inviation manager lambda function to run in master account.
+Description: Mozilla Multi Account Manager invitation manager lambda function to run in master account.
 Metadata:
   Source: https://github.com/mozilla/guardduty-multi-account-manager/tree/master/cloudformation
 Parameters:

--- a/cloudformation/guardduty-invitation-manager.yml
+++ b/cloudformation/guardduty-invitation-manager.yml
@@ -123,7 +123,7 @@ Resources:
   InvitationManagerFunction:
     Type: AWS::Lambda::Function
     Properties:
-      Runtime: python3.6
+      Runtime: python3.9
       Timeout: 900
       Handler: lambda_functions/invitation_manager.handle
       Role: !GetAtt InvitationManagerIAMRole.Arn

--- a/cloudformation/guardduty-invitation-manager.yml
+++ b/cloudformation/guardduty-invitation-manager.yml
@@ -72,7 +72,6 @@ Resources:
                 Resource:
                   - arn:aws:iam::*:role/multi-account-guard-duty/*
                   - arn:aws:iam::*:role/mutli-account-guard-duty/*
-                  - !Ref OrganizationAccountArns
         - PolicyName: "AllowRoleAssumptionOfOrgReaders"
           PolicyDocument:
             Version: "2012-10-17"

--- a/cloudformation/guardduty-invitation-manager.yml
+++ b/cloudformation/guardduty-invitation-manager.yml
@@ -6,14 +6,18 @@ Parameters:
   AccountFilterList:
     Type: String
     Default: ''
-    Description: Space delimited list of account IDs to filter on. Leave this empty to process all accounts
+    Description: >
+      Space delimited list of account IDs to filter on. If this is set, only
+      these accounts will be processed. If this is empty all accounts will be
+      processed.
   OrganizationAccountArns:
     Type: String
     Default: ''
     Description: >
-      ARNs of IAM Roles to assume in order to query the AWS Organization parents
-      if the Org parents are different AWS accounts. Leave this empty if you are
-      deploying within a single AWS Organization parent account
+      Comma delimited list of ARNs of IAM Roles to assume in order to query the
+      AWS Organization parents if the Org parents are different AWS accounts. 
+      Leave this empty if you are deploying this stack within a single AWS 
+      Organization parent account.
   LambdaCodeS3BucketNamePrefix:
     Type: String
     Default: public.

--- a/lambda_functions/invitation_manager.py
+++ b/lambda_functions/invitation_manager.py
@@ -135,7 +135,7 @@ def get_account_id_email_map_from_organizations(boto_session, region_name):
 def get_account_role_map(boto_session, region_name):
     """Fetch the ARNs of all the IAM Roles which people have created in other
     AWS accounts which are inserted into DynamoDB with
-    http://github.com/mozilla/cloudformation-cross-account-outputs
+    https://github.com/mozilla/cloudformation-cross-account-outputs
 
     :return: dict with account ID keys and IAM Role ARN values
     """
@@ -309,9 +309,8 @@ def handle(event, context):
             client.delete_members(
                 AccountIds=account_ids_to_delete,
                 DetectorId=local_detector_id)
-            logger.info(
-                '{} : Member deleted due to email verification failure : {}'.format(
-                    region_name, account_ids_to_delete))
+            logger.info('{} : Member deleted due to email verification failure'
+                        ' : {}'.format(region_name, account_ids_to_delete))
 
         # Invite members that have been created
         account_ids_to_invite = get_members('CREATED', 'RESIGNED')

--- a/lambda_functions/invitation_manager.py
+++ b/lambda_functions/invitation_manager.py
@@ -135,7 +135,7 @@ def get_account_id_email_map_from_organizations(boto_session, region_name):
 def get_account_role_map(boto_session, region_name):
     """Fetch the ARNs of all the IAM Roles which people have created in other
     AWS accounts which are inserted into DynamoDB with
-    http://github.com/gene1wood/cloudformation-cross-account-outputs
+    http://github.com/mozilla/cloudformation-cross-account-outputs
 
     :return: dict with account ID keys and IAM Role ARN values
     """

--- a/lambda_functions/invitation_manager.py
+++ b/lambda_functions/invitation_manager.py
@@ -226,7 +226,9 @@ def handle(event, context):
     Set environment variables
       * ORGANIZATION_IAM_ROLE_ARN_LIST : Comma delimited list of IAM Role ARNs
         to assume to reach AWS Organization parent accounts
-      * ACCOUNT_FILTER_LIST : Space delimited list of account IDs to filter on
+      * ACCOUNT_FILTER_LIST : Space delimited list of account IDs to include.
+        If this is provided, only these accounts will be included. If it's not
+        provided, all accounts will be included.
 
     :param event: Lambda event object
     :param context: Lambda context object

--- a/lambda_functions/plumbing.py
+++ b/lambda_functions/plumbing.py
@@ -4,7 +4,6 @@ Ensure continued publishing to
 import boto3
 import json
 import os
-import uuid
 
 from botocore.exceptions import ClientError
 


### PR DESCRIPTION
* Improve Getting Started in the README
* Clarify how to deploy just account management without the MozDef elements
* Remove leftover resource line in policy
  * This line would have only ever worked if one organization ARN was provided. This capability is correctly implemented in the AllowRoleAssumptionOfOrgReaders policy below.
* Fix typo in template description
* Switch from Travis to GitHub actions
* Clarify documentation of parameters

Fixes #43
